### PR TITLE
Add kim_query command to KIM v2 update PR

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -452,18 +452,24 @@ if(PKG_USER-VTK)
 endif()
 
 if(PKG_KIM)
+  find_package(CURL)
+  if(CURL_FOUND)
+    include_directories(${CURL_INCLUDE_DIRS}) 
+    list(APPEND LAMMPS_LINK_LIBS ${CURL_LIBRARIES})
+    add_definitions(-DLMP_KIM_CURL)
+  endif()
   option(DOWNLOAD_KIM "Download kim-api (instead of using the system's one)" OFF)
   if(DOWNLOAD_KIM)
     include(ExternalProject)
     ExternalProject_Add(kim_build
-      URL https://github.com/openkim/kim-api/archive/v1.9.5.tar.gz
-      URL_MD5 9f66efc128da33039e30659f36fc6d00
+      URL https://s3.openkim.org/kim-api/kim-api-v2.0.0-beta.1.txz
+      URL_MD5 da92fa8b3f404fcc2a2ed6c291ea155c
       BUILD_IN_SOURCE 1
       CONFIGURE_COMMAND <SOURCE_DIR>/configure --prefix=<INSTALL_DIR>
       )
     ExternalProject_get_property(kim_build INSTALL_DIR)
-    set(KIM_INCLUDE_DIRS ${INSTALL_DIR}/include/kim-api-v1)
-    set(KIM_LIBRARIES ${INSTALL_DIR}/lib/libkim-api-v1.so)
+    set(KIM_INCLUDE_DIRS ${INSTALL_DIR}/include/kim-api-v2)
+    set(KIM_LIBRARIES ${INSTALL_DIR}/lib/libkim-api-v2.so)
     list(APPEND LAMMPS_DEPS kim_build)
   else()
     find_package(KIM)

--- a/doc/src/Build_extras.txt
+++ b/doc/src/Build_extras.txt
@@ -153,7 +153,9 @@ KIM package :h4,link(kim)
 
 To build with this package, the KIM library must be downloaded and
 built on your system.  It must include the KIM models that you want to
-use with LAMMPS.
+use with LAMMPS. If you want to use the "kim_query"_kim_query.html
+command, you also need to have libcurl installed with the matching
+development headers and the curl-config tool.
 
 Note that in LAMMPS lingo, a KIM model driver is a pair style
 (e.g. EAM or Tersoff).  A KIM model is a pair style for a particular

--- a/doc/src/Packages_details.txt
+++ b/doc/src/Packages_details.txt
@@ -336,6 +336,8 @@ KIM package :link(PKG-KIM),h4
 A "pair_style kim"_pair_kim.html command which is a wrapper on the
 Knowledge Base for Interatomic Models (KIM) repository of interatomic
 potentials, enabling any of them to be used in LAMMPS simulations.
+Also a "kim_query"_kim_query.html command, which allows to query
+the OpenKIM database for stored properties.
 
 To use this package you must have the KIM library available on your
 system.

--- a/doc/src/commands_list.txt
+++ b/doc/src/commands_list.txt
@@ -50,6 +50,7 @@ Commands :h1
    include
    info
    jump
+   kim_query
    kspace_modify
    kspace_style
    label

--- a/doc/src/kim_query.txt
+++ b/doc/src/kim_query.txt
@@ -1,0 +1,46 @@
+"LAMMPS WWW Site"_lws - "LAMMPS Documentation"_ld - "LAMMPS Commands"_lc :c
+
+:link(lws,http://lammps.sandia.gov)
+:link(ld,Manual.html)
+:link(lc,Commands_all.html)
+
+:line
+
+kim_query command :h3
+
+[Syntax:]
+
+kim_query variable query_function web_query_flags :pre
+
+variable = name of a (string style) variable where the result of the query is stored
+query_function = name of the OpenKIM web API query function to be used
+web_query_flags = a series of keyword=value pairs that represent the web query; supported keywords depend on query function :ul
+
+[Examples:]
+
+kim_query latconst get_test_result test=TE_156715955670_004 model=MO_800509458712_001 &
+  prop=structure-cubic-crystal-npt species=\["Al"\] keys=\["a"\] units=\["angstrom"\] :pre
+
+[Description:]
+
+The kim_query command allows to retrieve properties from the OpenKIM
+through a web query. The result is stored in a string style
+"variable"_variable.html, the name of which must be given as the first
+argument of the kim_query command. The second required argument is the
+name of the actual query function (e.g. {get_test_result}). All following
+arguments are parameters handed over to the web query in the format
+{keyword=value}. This list of supported keywords and the type of how
+the value has to be encoded depends on the query function used.
+For more details on this, please refer to the OpenKIM homepage.
+
+[Restrictions:]
+
+This command is part of the KIM package.  It is only enabled if
+LAMMPS was built with that package.  Furthermore, its correct
+functioning is dependend on compiling LAMMPS with libcurl support.
+See the "Build package"_Build_package.html doc page for more info.
+
+[Related commands:]
+
+"pair_style kim"_pair_kim.html, "variable"_variable.html
+

--- a/doc/src/lammps.book
+++ b/doc/src/lammps.book
@@ -162,6 +162,7 @@ if.html
 include.html
 info.html
 jump.html
+kim_query.html
 label.html
 lattice.html
 log.html

--- a/doc/src/pair_kim.txt
+++ b/doc/src/pair_kim.txt
@@ -46,12 +46,9 @@ section of the "Packages details"_Packages_details.html doc page has
 instructions on how to do this with a simple make command, when
 building LAMMPS.
 
-See the examples/kim dir for an input script that uses a KIM model (potential)
-for Lennard-Jones.  Note, for this example input script, the example models
-shipped with with kim-api package must be installed.  See the "Making
-LAMMPS"_Section_start.html#start_3 section and the ./lib/kim/README for details
-on how to build LAMMSPS with the kim-api and how to install the example models.
-
+See the examples/kim dir for an input script that uses a KIM model
+(potential) for Lennard-Jones.
+ 
 :line
 
 The argument {model} is the name of the KIM model for a specific

--- a/examples/kim/in.query
+++ b/examples/kim/in.query
@@ -1,0 +1,11 @@
+
+# example for performing a query to the OpenKIM test database to retrieve
+# a parameter to be used in the input. here it requests the aluminium
+# lattice constant for a specific test used for a specific model and then
+# assigns it to the variable 'latconst'
+
+units metal
+info variables out log
+kim_query latconst get_test_result test=TE_156715955670_004 species=["Al"] model=MO_800509458712_001 prop=structure-cubic-crystal-npt keys=["a"] units=["angstrom"] 
+info variables out log
+lattice fcc ${latconst}

--- a/examples/kim/log.16Aug2018.query.g++.1
+++ b/examples/kim/log.16Aug2018.query.g++.1
@@ -1,0 +1,34 @@
+LAMMPS (16 Aug 2018)
+
+# example for performing a query to the OpenKIM test database to retrieve
+# a parameter to be used in the input. here it requests the aluminium
+# lattice constant for a specific test used for a specific model and then
+# assigns it to the variable 'latconst'
+
+units metal
+info variables out log
+
+Info-Info-Info-Info-Info-Info-Info-Info-Info-Info-Info
+Printed on Mon Aug 20 18:44:24 2018
+
+
+Variable information:
+
+Info-Info-Info-Info-Info-Info-Info-Info-Info-Info-Info
+
+kim_query latconst get_test_result test=TE_156715955670_004 species=["Al"] model=MO_800509458712_001 prop=structure-cubic-crystal-npt keys=["a"] units=["angstrom"]
+info variables out log
+
+Info-Info-Info-Info-Info-Info-Info-Info-Info-Info-Info
+Printed on Mon Aug 20 18:44:24 2018
+
+
+Variable information:
+Variable[  0]: latconst  ,  style = string    ,  def = 4.0320827961
+
+Info-Info-Info-Info-Info-Info-Info-Info-Info-Info-Info
+
+lattice fcc ${latconst}
+lattice fcc 4.0320827961
+Lattice spacing in x,y,z = 4.03208 4.03208 4.03208
+Total wall time: 0:00:00

--- a/lib/kim/Makefile.lammps
+++ b/lib/kim/Makefile.lammps
@@ -27,6 +27,13 @@ ifeq ($(shell $(KIM_CONFIG_HELPER) --version 2> /dev/null),)
   $(error $(KIM_CONFIG_HELPER) utility is not available.  Something is wrong with your KIM API package setup)
 endif
 
+# there is no usable libcurl installation
+ifeq ($(shell curl-config --version 2> /dev/null),)
 kim_SYSINC  = $(shell $(KIM_CONFIG_HELPER) --includes)
 kim_SYSLIB  = $(shell $(KIM_CONFIG_HELPER) --ldlibs)
 kim_SYSPATH = $(shell $(KIM_CONFIG_HELPER) --ldflags)
+else
+kim_SYSINC  = $(shell $(KIM_CONFIG_HELPER) --includes) $(shell curl-config --cflags) -DLMP_KIM_CURL
+kim_SYSLIB  = $(shell $(KIM_CONFIG_HELPER) --ldlibs)   $(shell curl-config --libs)
+kim_SYSPATH = $(shell $(KIM_CONFIG_HELPER) --ldflags)
+endif

--- a/lib/kim/README
+++ b/lib/kim/README
@@ -14,6 +14,12 @@ do the same thing by typing "python Install.py" from within this
 directory, or you can do it manually by following the instructions
 below.
 
+As of KIM API version 2, the KIM package also provides a LAMMPS command
+to perform queries through the OpenKIM web API. This feature requires
+that the CURL library (libcurl) development package and its configuration
+query tool, curl-config, are installed. The provided Makefile.lammps
+is set up to automatically detect this. 
+
 -----------------
 
 Instructions:

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -25,6 +25,11 @@
 /*_ssa.h
 /*_ssa.cpp
 
+/kim_query.cpp
+/kim_query.h
+/pair_kim.cpp
+/pair_kim.h
+
 /kokkos.cpp
 /kokkos.h
 /kokkos_type.h
@@ -764,8 +769,6 @@
 /pair_hbond_dreiding_morse.h
 /pair_ilp_graphene_hbn.cpp
 /pair_ilp_graphene_hbn.h
-/pair_kim.cpp
-/pair_kim.h
 /pair_kolmogorov_crespi_full.cpp
 /pair_kolmogorov_crespi_full.h
 /pair_kolmogorov_crespi_z.cpp

--- a/src/KIM/kim_query.cpp
+++ b/src/KIM/kim_query.cpp
@@ -1,0 +1,116 @@
+/* ----------------------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+
+/* ----------------------------------------------------------------------
+   Contributing authors: Axel Kohlmeyer (Temple U),
+                         Ryan S. Elliott (UMN)
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the Free
+   Software Foundation; either version 2 of the License, or (at your option)
+   any later version.
+
+   This program is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+   more details.
+
+   You should have received a copy of the GNU General Public License along with
+   this program; if not, see <https://www.gnu.org/licenses>.
+
+   Linking LAMMPS statically or dynamically with other modules is making a
+   combined work based on LAMMPS. Thus, the terms and conditions of the GNU
+   General Public License cover the whole combination.
+
+   In addition, as a special exception, the copyright holders of LAMMPS give
+   you permission to combine LAMMPS with free software programs or libraries
+   that are released under the GNU LGPL and with code included in the standard
+   release of the "kim-api" under the CDDL (or modified versions of such code,
+   with unchanged license). You may copy and distribute such a system following
+   the terms of the GNU GPL for LAMMPS and the licenses of the other code
+   concerned, provided that you include the source code of that other code
+   when and as the GNU GPL requires distribution of source code.
+
+   Note that people who make modified versions of LAMMPS are not obligated to
+   grant this special exception for their modified versions; it is their choice
+   whether to do so. The GNU General Public License gives permission to release
+   a modified version without this exception; this exception also makes it
+   possible to release a modified version which carries forward this exception.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Designed for use with the kim-api-v2.0.0-beta.1 (and newer) package
+------------------------------------------------------------------------- */
+
+#include <mpi.h>
+#include <cstring>
+#include "kim_query.h"
+#include "comm.h"
+#include "error.h"
+#include "input.h"
+#include "variable.h"
+
+using namespace LAMMPS_NS;
+
+static char *do_query(char *, char *, int, MPI_Comm);
+
+/* ---------------------------------------------------------------------- */
+
+void KimQuery::command(int narg, char **arg)
+{
+  char *model, *property, *varname, *value;
+
+  if (narg != 3) error->all(FLERR,"Illegal kim_query command");
+
+  model = arg[0];
+  property = arg[1];
+  varname = arg[2];
+
+  value = do_query(model, property, comm->me, world);
+
+  if (comm->me == 0)
+    printf("property %s for model %s is %s\n",property,model,value);
+
+  char **varcmd = new char*[3];
+  varcmd[0] = varname;
+  varcmd[1] = (char *) "string";
+  varcmd[2] = value;
+
+  input->variable->set(3,varcmd);
+  
+  delete[] varcmd;
+  delete[] value;
+}
+
+
+char *do_query(char *model, char *property, int rank, MPI_Comm comm)
+{
+  char val[512], *retval;
+  int len;
+
+  // only run query from rank 0
+  if (rank == 0) {
+
+    // fake query
+    strcpy(val,(const char*)"4.25");
+  }
+  MPI_Bcast(val, 512, MPI_CHAR, 0, comm);
+  len = strlen(val) + 1;
+  retval = new char[len];
+  strcpy(retval,val);
+    
+  return retval;
+}

--- a/src/KIM/kim_query.cpp
+++ b/src/KIM/kim_query.cpp
@@ -57,36 +57,55 @@
 
 #include <mpi.h>
 #include <cstring>
+#include <string>
 #include "kim_query.h"
 #include "comm.h"
 #include "error.h"
 #include "input.h"
 #include "variable.h"
 
+#include <sys/types.h>
+#include <curl/curl.h>
+
 using namespace LAMMPS_NS;
 
-static char *do_query(char *, char *, int, MPI_Comm);
+#if defined(LMP_KIM_CURL)
+
+struct WriteBuf {
+  char *dataptr;
+  size_t sizeleft;
+};
+
+static char *do_query(char *, int, char **, int, MPI_Comm);
+static size_t write_callback(void *, size_t, size_t, void *);
+
+#endif
 
 /* ---------------------------------------------------------------------- */
 
 void KimQuery::command(int narg, char **arg)
 {
-  char *model, *property, *varname, *value;
+  char *varname, *function, *value;
 
-  if (narg != 3) error->all(FLERR,"Illegal kim_query command");
+  if (narg < 2) error->all(FLERR,"Illegal kim_query command");
 
-  model = arg[0];
-  property = arg[1];
-  varname = arg[2];
+  varname = arg[0];
+  function = arg[1];
 
-  value = do_query(model, property, comm->me, world);
+#if defined(LMP_KIM_CURL)
+
+  value = do_query(function, narg-2, arg+2, comm->me, world);
 
   // check for valid result
+  // on error the content of "value" is a '\0' byte
+  // as the first element, and then the error message
+  // that was returned by the web server
 
-  int len = strlen(value) + 1;
-  if (len == 1) {
-    // TODO: store more detailed error message after \0 byte.
-    error->all(FLERR,"Query of OpenKIM database failed");
+  if (0 == strlen(value)) {
+    char errmsg[512];
+
+    sprintf(errmsg,"OpenKIM query failed: %s",value+1);
+        error->all(FLERR,errmsg);
   }
 
   char **varcmd = new char*[3];
@@ -98,26 +117,119 @@ void KimQuery::command(int narg, char **arg)
   
   delete[] varcmd;
   delete[] value;
+#else
+  error->all(FLERR,"Cannot use 'kim_query' command when KIM package "
+             "is compiled without support for libcurl");
+#endif
 }
 
+#if defined(LMP_KIM_CURL)
 
-char *do_query(char *model, char *property, int rank, MPI_Comm comm)
+// copy data to the user provided data structure, optionally in increments
+
+size_t write_callback(void *data, size_t size, size_t nmemb, void *userp)
+{
+  struct WriteBuf *buf = (struct WriteBuf *)userp;
+  size_t buffer_size = size*nmemb;
+
+  // copy chunks into the buffer for as long as there is space left
+  if (buf->sizeleft) {
+    size_t copy_this_much = buf->sizeleft;
+    if (copy_this_much > buffer_size)
+      copy_this_much = buffer_size;
+    memcpy(buf->dataptr, data, copy_this_much);
+
+    buf->dataptr += copy_this_much;
+    buf->sizeleft -= copy_this_much;
+    return copy_this_much;
+  }
+  return 0; // done
+}
+
+char *do_query(char *qfunction, int narg, char **arg, int rank, MPI_Comm comm)
 {
   char value[512], *retval;
 
-  // only run query from rank 0
-  if (rank == 0) {
+  // run the web query from rank 0 only
 
-    // fake query
-    strcpy(value,(const char*)"4.25");
+  if (rank == 0) {
+    CURL *handle;
+    CURLcode res;
+
+    // set up and clear receive buffer
+
+    struct WriteBuf buf;
+    buf.dataptr = value;
+    buf.sizeleft = 511;
+    memset(value,0,512);
+
+    // create curl web query instance
+    curl_global_init(CURL_GLOBAL_DEFAULT);
+    handle = curl_easy_init();
+
+    if (handle) {
+      std::string url("https://query.openkim.org/api/");
+      url += qfunction;
+
+      std::string query(arg[0]);
+      for (int i=1; i < narg; ++i) {
+        query += '&';
+        query += arg[i];
+      }
+
+#if LMP_DEBUG_CURL
+      curl_easy_setopt(handle, CURLOPT_VERBOSE, 1L);
+#endif
+
+#if defined(LMP_NO_SSL_CHECK)
+      // disable verifying SSL certificate and host name
+      curl_easy_setopt(handle, CURLOPT_SSL_VERIFYPEER, 0L);
+      curl_easy_setopt(handle, CURLOPT_SSL_VERIFYHOST, 0L);
+#endif
+
+      curl_easy_setopt(handle, CURLOPT_URL, url.c_str());
+      curl_easy_setopt(handle, CURLOPT_FOLLOWLOCATION, 1L);
+      curl_easy_setopt(handle, CURLOPT_POSTFIELDS, query.c_str());
+
+      curl_easy_setopt(handle, CURLOPT_WRITEFUNCTION,write_callback);
+      curl_easy_setopt(handle, CURLOPT_WRITEDATA,&buf);
+
+      // perform OpenKIM query and check for errors
+      res = curl_easy_perform(handle);
+      if (res != CURLE_OK) {
+        // on error we return an "empty" string but add error message after it
+        value[0]= '\0';
+        strcpy(value+1,curl_easy_strerror(res));
+      }
+      curl_easy_cleanup(handle);
+    }
+    curl_global_cleanup();
   }
   MPI_Bcast(value, 512, MPI_CHAR, 0, comm);
 
-  // must make a proper copy of the query, as the stack allocation
-  // will go out of scope
+  // we must make a proper copy of the query, as the stack allocation
+  // for "value" will go out of scope. a valid query has a '[' as
+  // the first character. skip over it (and the last character ']', too)
+  // an error messages starts with a '\0' character. copy that and
+  // the remaining string, as that is the error message.
 
-  int len = strlen(value) + 1;
-  retval = new char[len];
-  strcpy(retval,value);
+  if (value[0] == '[') {
+    int len = strlen(value)-1;
+    retval = new char[len];
+    value[len] = '\0';
+    strcpy(retval,value+1);
+  } else if (value[0] == '\0') {
+    int len = strlen(value+1)+2;
+    retval = new char[len];
+    retval[0] = '\0';
+    strcpy(retval+1,value+1);
+  } else {
+    // unknown response type. we should not get here.
+    // copy response without modifications.
+    int len = strlen(value)+1;
+    retval = new char[len];
+    strcpy(retval,value);
+  }
   return retval;
 }
+#endif

--- a/src/KIM/kim_query.h
+++ b/src/KIM/kim_query.h
@@ -1,0 +1,85 @@
+/* -*- c++ -*- ----------------------------------------------------------
+   LAMMPS - Large-scale Atomic/Molecular Massively Parallel Simulator
+   http://lammps.sandia.gov, Sandia National Laboratories
+   Steve Plimpton, sjplimp@sandia.gov
+
+   Copyright (2003) Sandia Corporation.  Under the terms of Contract
+   DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government retains
+   certain rights in this software.  This software is distributed under
+   the GNU General Public License.
+
+   See the README file in the top-level LAMMPS directory.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Contributing authors: Axel Kohlmeyer (Temple U),
+                         Ryan S. Elliott (UMN)
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   This program is free software; you can redistribute it and/or modify it
+   under the terms of the GNU General Public License as published by the Free
+   Software Foundation; either version 2 of the License, or (at your option)
+   any later version.
+
+   This program is distributed in the hope that it will be useful, but WITHOUT
+   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+   FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+   more details.
+
+   You should have received a copy of the GNU General Public License along with
+   this program; if not, see <https://www.gnu.org/licenses>.
+
+   Linking LAMMPS statically or dynamically with other modules is making a
+   combined work based on LAMMPS. Thus, the terms and conditions of the GNU
+   General Public License cover the whole combination.
+
+   In addition, as a special exception, the copyright holders of LAMMPS give
+   you permission to combine LAMMPS with free software programs or libraries
+   that are released under the GNU LGPL and with code included in the standard
+   release of the "kim-api" under the CDDL (or modified versions of such code,
+   with unchanged license). You may copy and distribute such a system following
+   the terms of the GNU GPL for LAMMPS and the licenses of the other code
+   concerned, provided that you include the source code of that other code
+   when and as the GNU GPL requires distribution of source code.
+
+   Note that people who make modified versions of LAMMPS are not obligated to
+   grant this special exception for their modified versions; it is their choice
+   whether to do so. The GNU General Public License gives permission to release
+   a modified version without this exception; this exception also makes it
+   possible to release a modified version which carries forward this exception.
+------------------------------------------------------------------------- */
+
+/* ----------------------------------------------------------------------
+   Designed for use with the kim-api-v2.0.0-beta.1 (and newer) package
+------------------------------------------------------------------------- */
+
+#ifdef COMMAND_CLASS
+
+CommandStyle(kim_query,KimQuery)
+
+#else
+
+#ifndef LMP_KIM_QUERY_H
+#define LMP_KIM_QUERY_H
+
+#include "pointers.h"
+
+namespace LAMMPS_NS {
+
+class KimQuery : protected Pointers {
+ public:
+  KimQuery(class LAMMPS *lmp) : Pointers(lmp) {};
+  void command(int, char **);
+
+};
+
+}
+
+#endif
+#endif
+
+/* ERROR/WARNING messages:
+
+
+*/


### PR DESCRIPTION
## Purpose

This PR adds a new command `kim_query` to the KIM package. The command allows to query the OpenKIM database and store the result of the query into a string style variable, which can then be used elsewhere in the input script.

The query is implemented on top of libcurl and in a rather minimal way, leaving most of the syntax and error checking to the CGI script on the OpenKIM web servers.

## Author(s)

Axel Kohlmeyer (Temple U)

## Backward Compatibility

N/A

## Implementation Notes

The command is a rather minimal wrapper around polling a web API using libcurl.
It tries to auto-detect the presence of libcurl for the conventional build system.
CMake support (on the LAMMPS side) is included as well and libcurl detected and the define set as needed.

## Post Submission Checklist

_Please check the fields below as they are completed_
- [ ] The feature or features in this pull request is complete
- [x] Suitable new documentation files and/or updates to the existing docs are included
- [x] One or more example input decks are included
- [x] The source code follows the LAMMPS formatting guidelines


